### PR TITLE
add sonic pi server path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub fn start_server() {
         String::from("/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb"),
         String::from("/opt/sonic-pi/app/server/ruby/bin/sonic-pi-server.rb"),
         String::from("/usr/lib/sonic-pi/server/ruby/bin/sonic-pi-server.rb"),
+        String::from("/usr/lib/sonic-pi/app/server/ruby/bin/sonic-pi-server.rb"),
     ];
 
     if let Some(home_directory) = dirs::home_dir() {


### PR DESCRIPTION
The Sonic Pi server path on version 3.2.2, on Debian, has changed path to /usr/lib/sonic-pi/app/. This PR adds that path to it.